### PR TITLE
Add missing include <memory> for std::weak_ptr

### DIFF
--- a/TentakelsAttacking2/Game/public/SpaceObject.h
+++ b/TentakelsAttacking2/Game/public/SpaceObject.h
@@ -6,6 +6,7 @@
 #pragma once
 #include "Vec2.hpp"
 #include <string>
+#include <memory> // for std::weak_ptr
 
 class Galaxy;
 class Player;


### PR DESCRIPTION
The type `std::weak_ptr` is defined in the header `<memory>` and should be included for its usage.