### PR TITLE
Add missing includes, remove shadowing param, HRandom.h capitalization

### DIFF
--- a/TentakelsAttacking2/Events/public/EventManager.hpp
+++ b/TentakelsAttacking2/Events/public/EventManager.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 #include "EventListener.hpp"
+#include <algorithm>
 #include <vector>
 
  class  EventManager final {

--- a/TentakelsAttacking2/Game/public/GameManager.h
+++ b/TentakelsAttacking2/Game/public/GameManager.h
@@ -10,7 +10,7 @@
 #include "GenerelEvents.hpp"
 #include "GameEventTypes.hpp"
 #include <vector>
-#include <memory> // for shared_ptr
+#include <memory>
 
 class GameManager final : public EventListener {
 private:

--- a/TentakelsAttacking2/Game/public/GameManager.h
+++ b/TentakelsAttacking2/Game/public/GameManager.h
@@ -10,6 +10,7 @@
 #include "GenerelEvents.hpp"
 #include "GameEventTypes.hpp"
 #include <vector>
+#include <memory> // for shared_ptr
 
 class GameManager final : public EventListener {
 private:

--- a/TentakelsAttacking2/Helper/public/HGeneral.h
+++ b/TentakelsAttacking2/Helper/public/HGeneral.h
@@ -5,6 +5,7 @@
 
 #pragma once
 #include <raylib.h>
+#include <cstddef>
 
 // Colors
 [[nodiscard]] bool operator==(Color lhs, Color rhs);

--- a/TentakelsAttacking2/Helper/public/HSoundManager.h
+++ b/TentakelsAttacking2/Helper/public/HSoundManager.h
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <array>
 #include <vector>
+#include <string>
 
 
 class SoundManager final : public EventListener {

--- a/TentakelsAttacking2/Helper/public/LayeredVector.hpp
+++ b/TentakelsAttacking2/Helper/public/LayeredVector.hpp
@@ -4,6 +4,7 @@
 //
 
 #pragma once
+#include <algorithm> // for std::remove
 #include <vector>
 #include <stdexcept>
 #include <string>

--- a/TentakelsAttacking2/Helper/public/Vec2.hpp
+++ b/TentakelsAttacking2/Helper/public/Vec2.hpp
@@ -47,10 +47,10 @@ struct Vec2 final {
 		return Vec2<T>(x * other.x, y * other.y);
 	}
 
-	template<typename To>
-	Vec2<To> To() const {
-		static_assert(std::is_floating_point_v<To>, "floting point required");
-		return Vec2<To>(static_cast<To>(x), static_cast<To>(y));
+	template<typename Scalar>
+	Vec2<Scalar> To() const {
+		static_assert(std::is_floating_point_v<Scalar>, "floting point required");
+		return Vec2<Scalar>(static_cast<Scalar>(x), static_cast<Scalar>(y));
 	}
 	[[nodiscard]] std::string ToString() const {
 		return "X: " + std::to_string(x) + " Y: " + std::to_string(y);

--- a/TentakelsAttacking2/UI/Scene/MainScenes/private/Intro.cpp
+++ b/TentakelsAttacking2/UI/Scene/MainScenes/private/Intro.cpp
@@ -10,7 +10,7 @@
 #include "Text.h"
 #include "Title.h"
 #include "SceneType.hpp"
-#include "Hrandom.h"
+#include "HRandom.h"
 #include "HInput.h"
 
 


### PR DESCRIPTION
- EventManager: include algorithm for std::remove
- HGeneral: include cstddef for size_t
- HSoundManager: missing string include
- Vec2: rename shadowing template parameter
- GameManager: memory include for shared_ptr
- Intro: fix capitalization for HRandom.h include
- LayeredVector: add algorithm include for std::remove