### PR TITLE
UIManager: initialize m_closeWindow variable to false

### DIFF
--- a/TentakelsAttacking2/UI/public/UIManager.h
+++ b/TentakelsAttacking2/UI/public/UIManager.h
@@ -22,7 +22,7 @@ private:
 	SceneManager m_sceneManager;
 	GameManager m_gameManager;
 	Vector2 m_resolution;
-	bool m_closeWindow;
+	bool m_closeWindow = false;
 
 	void ToggleFullScreen(bool first = false);
 


### PR DESCRIPTION
Initialize the boolean variable `m_closeWindow` to false. Otherwise the variable is filled with random memory (except in Debug builds on MSVC where the memory is default initialized to 0)