### PR TITLE
Vec2: add possibility to build with fmt

### DIFF
--- a/TentakelsAttacking2/Helper/public/Vec2.hpp
+++ b/TentakelsAttacking2/Helper/public/Vec2.hpp
@@ -5,7 +5,11 @@
 
 #pragma once
 #include <string>
+#ifdef USE_FMT_FORMAT
+#include <fmt/format.h>
+#else
 #include <format>
+#endif
 #include <stdexcept>
 #include <cmath>
 
@@ -31,7 +35,13 @@ struct Vec2 final {
 		return std::sqrt((X * X) + (Y * Y));
 	}
 	[[nodiscard]] std::string Display() const {
-		return std::format("x -> {} / y -> {}", x, y);
+		return
+#ifdef USE_FMT_FORMAT
+			fmt::format(
+#else
+			std::format(
+#endif
+				"x -> {} / y -> {}", x, y);
 	}
 
 	bool operator== (const Vec2<T>& other) const {


### PR DESCRIPTION
MSVC is basically currently the only compiler fully supporting the C++20 `<format>` header and its `std::format` function.

So add the possiblity to build with the excelent basis for
`std::format`: `fmt` https://github.com/fmtlib/fmt

The building with `std::format` is the default, building against `fmt` must be explicitly enabled