### PR TITLE
Button: fix Vector2 has no float constructor with initializer list

### DIFF
--- a/TentakelsAttacking2/UI/Elements/Button/private/Button.cpp
+++ b/TentakelsAttacking2/UI/Elements/Button/private/Button.cpp
@@ -61,7 +61,7 @@ Button::Button(Vector2 pos, Vector2 size, Alignment alignment,
 }
 
 Button::Button()
-	: UIElement(Vector2(0.0f,0.0f), Vector2(0.0f,0.0f), Alignment::TOP_LEFT),
+	: UIElement(Vector2{0.0f,0.0f}, Vector2{0.0f,0.0f}, Alignment::TOP_LEFT),
 	m_colider({ 0.0f,0.0f,0.0f,0.0f }), m_sound(SoundType::CLICKED_RELEASE_STD),
 	m_textPosition({ 0.0f,0.0f }), m_texture(nullptr), m_textureRec({0.0f,0.0f,0.0f,0.0f}) {}
 


### PR DESCRIPTION
The raylib C struct Vector2 has no Vector(float,float) constructor. Ubuntu-latest build breaks because the constructor is tried to be called with `Vector(0.0f,0.0f)`. Replace the constructor with an initializer list using `{}` to work around this limitation.