### PR TITLE
CI: explicitly run on Ubuntu 22.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,12 +21,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
         include:
           - os: windows-latest
             triplet: x64-windows
             preset: ninja-multi-vcpkg
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             triplet: x64-linux
             preset: ninja
     env:
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: "Install raylib Linux dependencies"
         run: sudo apt install -yq libxinerama-dev libxcursor-dev xorg-dev libglu1-mesa-dev pkg-config libgl1-mesa-dev libx11-dev libxcursor-dev libxinerama-dev libxrandr-dev libfmt-dev
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
 
       - uses: actions/checkout@v3
         with:
@@ -68,7 +68,7 @@ jobs:
           # Note: given a key, the cache content is immutable. If a cache entry has been created improperly, in order the recreate the right content the key must be changed as well, and it must be brand new (i.e. not existing already).
           key: |
             ${{ hashFiles( 'vcpkg.json' ) }}-${{ hashFiles( '.git/modules/vcpkg/HEAD' )}}-${{ matrix.triplet }}
-        if: ${{ matrix.os != 'ubuntu-latest' }}
+        if: ${{ matrix.os != 'ubuntu-22.04' }}
 
       - name: Show content of workspace after cache has been restored
         run: find $RUNNER_WORKSPACE


### PR DESCRIPTION
On Purpurs CI ubuntu-latest chose Ubuntu 20.04 to run on and on my fork the CI chose Ubuntu 22.04. Explicitly use Ubuntu 22.04 to prevent confusion and sometimes breaking CI jobs.