### PR TITLE
CI: linux: call apt update to get newest packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,9 @@ jobs:
       VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg/bincache
 
     steps:
+      - name: "Update apt chache to install raylib dependencies"
+        run: sudo apt-get update -q
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
       - name: "Install raylib Linux dependencies"
         run: sudo apt install -yq libxinerama-dev libxcursor-dev xorg-dev libglu1-mesa-dev pkg-config libgl1-mesa-dev libx11-dev libxcursor-dev libxinerama-dev libxrandr-dev libfmt-dev
         if: ${{ matrix.os == 'ubuntu-22.04' }}


### PR DESCRIPTION
The linux build did fail because apt install didn't find packages. I assume this is because the package cache was old and pointing to an old package, which was since updated and the old one removed

So make sure the apt cache is uptodate by updating it